### PR TITLE
fix: wrong install URL in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ func IsValidHostname(hostname string, fqdn bool) bool {
 ## Install
 
 ```
-go install github.com/butuzov/mirrror/cmd/mirror@latest
+go install github.com/butuzov/mirror/cmd/mirror@latest
 ```
 
 ## How to use


### PR DESCRIPTION
This PR replaces`mirrror` with `mirror` in `readme.md`.