### PR TITLE
byte/rune support

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -12,7 +12,7 @@ tasks:
     - task: lints
     # - make test-generate
     - task: tests
-    - cmd: go run ./cmd/mirror/ --with-tests --with-debug ./demo
+    - cmd: go run ./cmd/mirror/ --with-tests --with-debug ./sandbox
       ignore_error: true
 
   testcase: go test -v -failfast -count=1 -run "TestAll/{{ .Case }}" ./...

--- a/analyzer.go
+++ b/analyzer.go
@@ -100,11 +100,15 @@ func Run(pass *analysis.Pass, withTests bool) []*checker.Violation {
 			}
 
 			pkgStruct, name := cleanAsterisk(tv.Type.String()), expr.Sel.Name
-			if v := check.Match(pkgStruct, name); v != nil {
+			for _, v := range check.Matches(pkgStruct, name) {
+				if v == nil {
+					continue
+				}
+
 				if args, found := check.Handle(v, callExpr); found {
 					violations = append(violations, v.With(check.Print(expr.X), callExpr, args))
+					return
 				}
-				return
 			}
 
 		case *ast.Ident:

--- a/checkers_bytes.go
+++ b/checkers_bytes.go
@@ -302,5 +302,25 @@ var (
 				Returns:      2,
 			},
 		},
+		{ // (*bytes.Buffer).WriteString -> (*bytes.Buffer).WriteRune
+			Targets:   checker.Strings,
+			Type:      checker.Method,
+			Package:   "bytes",
+			Struct:    "Buffer",
+			Caller:    "WriteString",
+			Args:      []int{0},
+			ArgsType:  checker.Rune,
+			AltCaller: "WriteRune",
+		},
+		{ // (*bytes.Buffer).WriteString -> (*bytes.Buffer).WriteByte
+			Targets:   checker.Strings,
+			Type:      checker.Method,
+			Package:   "bytes",
+			Struct:    "Buffer",
+			Caller:    "WriteString",
+			Args:      []int{0},
+			ArgsType:  checker.Byte,
+			AltCaller: "WriteByte",
+		},
 	}
 )

--- a/checkers_strings.go
+++ b/checkers_strings.go
@@ -275,5 +275,25 @@ var (
 				Returns:      2,
 			},
 		},
+		{ // (*strings.Builder).WriteString -> (*strings.Builder).WriteRune
+			Targets:   checker.Strings,
+			Type:      checker.Method,
+			Package:   "strings",
+			Struct:    "Builder",
+			Caller:    "WriteString",
+			Args:      []int{0},
+			ArgsType:  checker.Rune,
+			AltCaller: "WriteRune",
+		},
+		{ // (*strings.Builder).WriteString -> (*strings.Builder).WriteByte
+			Targets:   checker.Strings,
+			Type:      checker.Method,
+			Package:   "strings",
+			Struct:    "Builder",
+			Caller:    "WriteString",
+			Args:      []int{0},
+			ArgsType:  checker.Byte,
+			AltCaller: "WriteByte", // byte
+		},
 	}
 )

--- a/internal/checker/violation.go
+++ b/internal/checker/violation.go
@@ -21,14 +21,18 @@ const (
 )
 
 const (
-	Strings string = "string"
-	Bytes   string = "[]byte"
+	Strings     string = "string"
+	Bytes       string = "[]byte"
+	Byte        string = "byte"
+	Rune        string = "rune"
+	UntypedRune string = "untyped rune"
 )
 
 // Violation describs what message we going to give to a particular code violation
 type Violation struct {
-	Type ViolationType //
-	Args []int         // Indexes of the arguments needs to be checked
+	Type     ViolationType //
+	Args     []int         // Indexes of the arguments needs to be checked
+	ArgsType string
 
 	Targets    string
 	Package    string
@@ -59,6 +63,18 @@ func (v *Violation) With(base []byte, e *ast.CallExpr, args map[int]ast.Expr) *V
 	v.arguments = args
 
 	return v
+}
+
+func (v *Violation) getArgType() string {
+	if v.ArgsType != "" {
+		return v.ArgsType
+	}
+
+	if v.Targets == Strings {
+		return Bytes
+	}
+
+	return Strings
 }
 
 func (v *Violation) Message() string {

--- a/internal/checker/violation.go
+++ b/internal/checker/violation.go
@@ -198,3 +198,11 @@ func (v *Violation) Issue(fSet *token.FileSet) GolangIssue {
 
 	return issue
 }
+
+// ofType normalize input types (mostly typed and untyped runes).
+func normalType(s string) string {
+	if s == UntypedRune {
+		return Rune
+	}
+	return s
+}

--- a/internal/checker/violation_test.go
+++ b/internal/checker/violation_test.go
@@ -249,3 +249,51 @@ func TestComplex(t *testing.T) {
 		})
 	}
 }
+
+func TestArgType(t *testing.T) {
+	tests := []struct {
+		Name      string
+		Violation Violation
+		Expected  string
+	}{
+		{
+			Name: "DefaultStrings",
+			Violation: Violation{
+				Targets: Bytes,
+			},
+			Expected: Strings,
+		},
+		{
+			Name: "DefaultBytes",
+			Violation: Violation{
+				Targets: Strings,
+			},
+			Expected: Bytes,
+		},
+		{
+			Name: "NonDefault_Runes",
+			Violation: Violation{
+				Targets:  Strings,
+				ArgsType: Rune,
+			},
+			Expected: Rune,
+		},
+		{
+			Name: "NonDefault_Byte",
+			Violation: Violation{
+				Targets:  Strings,
+				ArgsType: Byte,
+			},
+			Expected: Byte,
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.Name, func(t *testing.T) {
+			if test.Violation.getArgType() != test.Expected {
+				t.Errorf("unexpected arg type: want(%s) vs got(%s)", test.Expected, test.Violation.getArgType())
+			}
+		})
+	}
+}

--- a/testdata/born-to-rune.go
+++ b/testdata/born-to-rune.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+func bornToRune() {
+	fmt.Printf("%T\n", 'п')
+	fmt.Printf("%T\n", `п`)
+	fmt.Printf("%T\n", "p"[0])
+
+	var bbuf bytes.Buffer
+	var sbuf strings.Builder
+	var r rune = 'п'
+	b := "p"[0]
+
+	sbuf.WriteString(string([]byte("foobar"))) // want `avoid allocations with \(\*strings\.Builder\)\.Write`
+	sbuf.WriteString(string('п'))              // want `avoid allocations with \(\*strings\.Builder\)\.WriteRune`
+	sbuf.WriteString(string('r'))              // want `avoid allocations with \(\*strings\.Builder\)\.WriteRune`
+	sbuf.WriteString(string(`п`))
+	sbuf.WriteString(string(b)) // want `avoid allocations with \(\*strings\.Builder\)\.WriteByte`
+
+	bbuf.WriteString(string([]byte("foobar"))) // want `avoid allocations with \(\*bytes\.Buffer\)\.Write`
+	bbuf.WriteString(string('п'))              // want `avoid allocations with \(\*bytes\.Buffer\)\.WriteRune`
+	bbuf.WriteString(string(r))                // want `avoid allocations with \(\*bytes\.Buffer\)\.WriteRune`
+	bbuf.WriteString(string(`п`))
+	bbuf.WriteString(string(b)) // want `avoid allocations with \(\*bytes\.Buffer\)\.WriteByte`
+
+	fmt.Println("strings.Builder:", sbuf.String())
+	fmt.Println("  bytes.Buffer:", bbuf.String())
+}

--- a/testdata/issue-26.go
+++ b/testdata/issue-26.go
@@ -12,6 +12,6 @@ func foobar_byte() {
 
 	fmt.Printf("%T\n", b)
 
-	strBuilder.WriteString(string(b))
+	strBuilder.WriteString(string(b)) // want `avoid allocations with \(\*strings\.Builder\)\.WriteByte`
 	fmt.Println(strBuilder.String())
 }


### PR DESCRIPTION
Adding support for alternative methods of `WriteString` method (see #26)

- `(*strings.Builder).WriteByte`
- `(*strings.Builder).WriteRune`
- `(*bytes.Buffer).WriteRune`
- `(*bytes.Buffer).WriteByte`