### PR TITLE
feature: Add bytes/strings NewReader support

### DIFF
--- a/MIRROR_FUNCS.md
+++ b/MIRROR_FUNCS.md
@@ -85,6 +85,10 @@
 <td><code>func bytes.NewBuffer(buf []byte *bytes.Buffer</code></td>
 </tr>
 <tr>
+<td><code>func strings.NewReader(s string) *Reader</code></td>
+<td><code>func bytes.NewReader(b []byte) *Reader</code></td>
+</tr>
+<tr>
 <td><code>func (h *hash/maphash.Hash) WriteString(s string) (int, error)</code></td>
 <td><code>func (h *hash/maphash.Hash) Write(b []byte) (int, error)</code></td>
 </tr>

--- a/checkers_bytes.go
+++ b/checkers_bytes.go
@@ -30,6 +30,20 @@ var (
 				Returns: 1,
 			},
 		},
+		{ // bytes.NewReader
+			Targets:    checker.Bytes,
+			Type:       checker.Function,
+			Package:    "bytes",
+			Caller:     "NewReader",
+			Args:       []int{0},
+			AltPackage: "strings",
+			AltCaller:  "NewReader",
+
+			Generate: &checker.Generate{
+				Pattern: `NewReader($0)`,
+				Returns: 1,
+			},
+		},
 		{ // bytes.Compare:
 			Targets:    checker.Bytes,
 			Type:       checker.Function,

--- a/checkers_strings.go
+++ b/checkers_strings.go
@@ -242,6 +242,20 @@ var (
 				Returns: 1,
 			},
 		},
+		{ // strings.NewReader
+			Targets:    checker.Strings,
+			Type:       checker.Function,
+			Package:    "strings",
+			Caller:     "NewReader",
+			Args:       []int{0},
+			AltPackage: "bytes",
+			AltCaller:  "NewReader",
+
+			Generate: &checker.Generate{
+				Pattern: `NewReader($0)`,
+				Returns: 1,
+			},
+		},
 	}
 
 	StringsBuilderMethods = []checker.Violation{

--- a/testdata/bytes.go
+++ b/testdata/bytes.go
@@ -821,6 +821,36 @@ func main_bytes() {
 	}
 
 	{
+		
+		_ = bytes.NewReader([]byte("foobar")) // want `avoid allocations with strings\.NewReader`
+	}
+
+	{
+		
+		_ = bytes.NewReader([]byte{'f','o','o','b','a','r'}) 
+	}
+
+	{
+		
+		_ = NewReader([]byte("foobar")) // want `avoid allocations with strings\.NewReader`
+	}
+
+	{
+		
+		_ = NewReader([]byte{'f','o','o','b','a','r'}) 
+	}
+
+	{
+		
+		_ = pkg.NewReader([]byte("foobar")) // want `avoid allocations with strings\.NewReader`
+	}
+
+	{
+		
+		_ = pkg.NewReader([]byte{'f','o','o','b','a','r'}) 
+	}
+
+	{
 		bb := bytes.Buffer{}
 		_,_ = bb.Write([]byte("foobar")) // want `avoid allocations with \(\*bytes\.Buffer\)\.WriteString`
 	}

--- a/testdata/strings.go
+++ b/testdata/strings.go
@@ -761,6 +761,36 @@ func main_strings() {
 	}
 
 	{
+		
+		_ = strings.NewReader(string([]byte{'f','o','o','b','a','r'})) // want `avoid allocations with bytes\.NewReader`
+	}
+
+	{
+		
+		_ = strings.NewReader("foobar") 
+	}
+
+	{
+		
+		_ = NewReader(string([]byte{'f','o','o','b','a','r'})) // want `avoid allocations with bytes\.NewReader`
+	}
+
+	{
+		
+		_ = NewReader("foobar") 
+	}
+
+	{
+		
+		_ = pkg.NewReader(string([]byte{'f','o','o','b','a','r'})) // want `avoid allocations with bytes\.NewReader`
+	}
+
+	{
+		
+		_ = pkg.NewReader("foobar") 
+	}
+
+	{
 		builder := strings.Builder{}
 		_,_ = builder.Write([]byte("foobar")) // want `avoid allocations with \(\*strings\.Builder\)\.WriteString`
 	}


### PR DESCRIPTION
Saw a few occurrences of this in my code, and noticed the linter wasn't picking them up.

`MIRROR_FUNCS.md` was edited manually, but the tests were generated with `make test-generate`.