### PR TITLE
docs: fix Contributing section in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -113,7 +113,7 @@ util/cert/cert.go:82:10: avoid allocations with (*regexp.Regexp).MatchString (mi
 
 ```shell
 # Update Assets (testdata/(strings|bytes|os|utf8|maphash|regexp|bufio).go)
-(task|make) generated
+(task|make) generate
 # Run Tests
 (task|make) tests
 # Lint Code


### PR DESCRIPTION
Because https://github.com/butuzov/mirror/blob/119512950703780ecb9e7b4d64a004d433938ce2/Makefile#L12 and https://github.com/butuzov/mirror/blob/119512950703780ecb9e7b4d64a004d433938ce2/Taskfile.yml#L18